### PR TITLE
Conversion table

### DIFF
--- a/PriceTracker.Data/ApplicationDBContext.cs
+++ b/PriceTracker.Data/ApplicationDBContext.cs
@@ -10,6 +10,7 @@ internal class ApplicationDBContext : IdentityDbContext<ApplicationUser>
     public DbSet<Entity.PriceHistory> PriceHistories { get; set; }
     public DbSet<Entity.Product> Products { get; set; }
     public DbSet<Entity.Store> Stores { get; set; }
+    public DbSet<Entity.UnitConversion> UnitConversions { get; set; }
     public DbSet<Entity.UnitOfMeasure> UnitOfMeasures { get; set; }
 
     public ApplicationDBContext(DbContextOptions options) : base(options)

--- a/PriceTracker.Data/Entity/PriceHistory.cs
+++ b/PriceTracker.Data/Entity/PriceHistory.cs
@@ -104,8 +104,7 @@ internal static class PriceHistoryExtensions
             {
                 Id = p.UnitOfMeasure.Id,
                 Name = p.UnitOfMeasure.Name,
-                Abbreviation = p.UnitOfMeasure.Abbreviation,
-                ConversionToGramsRatio = p.UnitOfMeasure.ConversionToGramsRatio
+                Abbreviation = p.UnitOfMeasure.Abbreviation
             },
             Store = p.Store == null ? null : new Data.Store.StoreModel()
             {

--- a/PriceTracker.Data/Entity/Product.cs
+++ b/PriceTracker.Data/Entity/Product.cs
@@ -69,8 +69,7 @@ internal static class ProductExtensions
                 {
                     Id = p.DefaultUnitOfMeasure.Id,
                     Name = p.DefaultUnitOfMeasure.Name,
-                    Abbreviation = p.DefaultUnitOfMeasure.Abbreviation,
-                    ConversionToGramsRatio = p.DefaultUnitOfMeasure.ConversionToGramsRatio
+                    Abbreviation = p.DefaultUnitOfMeasure.Abbreviation
                 }
             });
         }

--- a/PriceTracker.Data/Entity/UnitConversion.cs
+++ b/PriceTracker.Data/Entity/UnitConversion.cs
@@ -71,7 +71,6 @@ internal static class UnitConversionExtensions
             {
                 Id = p.SourceUnitOfMeasure.Id,
                 Abbreviation = p.SourceUnitOfMeasure.Abbreviation,
-                ConversionToGramsRatio = p.SourceUnitOfMeasure.ConversionToGramsRatio,
                 Name = p.SourceUnitOfMeasure.Name
             },
             DestinationUnitOfMeasureId = p.DestinationUnitOfMeasureId,
@@ -79,7 +78,6 @@ internal static class UnitConversionExtensions
             {
                 Id = p.DestinationUnitOfMeasure.Id,
                 Abbreviation = p.DestinationUnitOfMeasure.Abbreviation,
-                ConversionToGramsRatio = p.DestinationUnitOfMeasure.ConversionToGramsRatio,
                 Name = p.DestinationUnitOfMeasure.Name
             },
             ConversionRatio = p.ConversionRatio

--- a/PriceTracker.Data/Entity/UnitConversion.cs
+++ b/PriceTracker.Data/Entity/UnitConversion.cs
@@ -1,0 +1,88 @@
+﻿using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using PriceTracker.Data.UnitConversion;
+using System.Linq;
+
+namespace PriceTracker.Data.Entity;
+
+internal class UnitConversion
+{
+    public int Id { get; set; }
+
+    public int SourceUnitOfMeasureId { get; set; }
+
+    public UnitOfMeasure SourceUnitOfMeasure { get; set; }
+
+    public int DestinationUnitOfMeasureId { get; set; }
+
+    public UnitOfMeasure DestinationUnitOfMeasure { get; set; }
+
+    public decimal ConversionRatio { get; set; }
+}
+
+internal class UnitConversionConfiguration : IEntityTypeConfiguration<UnitConversion>
+{
+    public void Configure(EntityTypeBuilder<UnitConversion> builder)
+    {
+        builder.ToTable(nameof(UnitConversion));
+
+        builder.HasKey(p => p.Id);
+
+        builder.Property(p => p.ConversionRatio)
+            .HasColumnType("decimal(9,5)");
+
+        builder.HasOne(p => p.SourceUnitOfMeasure)
+            .WithMany()
+            .HasPrincipalKey(p => p.Id)
+            .HasForeignKey(p => p.SourceUnitOfMeasureId)
+            .OnDelete(DeleteBehavior.ClientCascade);
+
+        builder.HasOne(p => p.DestinationUnitOfMeasure)
+            .WithMany()
+            .HasPrincipalKey(p => p.Id)
+            .HasForeignKey(p => p.DestinationUnitOfMeasureId)
+            .OnDelete(DeleteBehavior.ClientCascade);
+
+        builder.HasIndex(p => new { p.SourceUnitOfMeasureId, p.DestinationUnitOfMeasureId })
+            .IsUnique(true)
+            .IsClustered(false);
+    }
+}
+
+internal static class UnitConversionExtensions
+{
+    public static UnitConversionModel AsModel(this UnitConversion entity)
+    {
+        return entity == null ? null : new UnitConversionModel()
+        {
+            SourceUnitOfMeasureId = entity.SourceUnitOfMeasureId,
+            SourceUnitOfMeasure = entity.SourceUnitOfMeasure.AsModel(),
+            DestinationUnitOfMeasureId = entity.DestinationUnitOfMeasureId,
+            DestinationUnitOfMeasure = entity.DestinationUnitOfMeasure.AsModel(),
+            ConversionRatio = entity.ConversionRatio
+        };
+    }
+
+    public static IQueryable<UnitConversionModel> ProjectToModel(this IQueryable<UnitConversion> query)
+    {
+        return query?.Select(p => new UnitConversionModel()
+        {
+            SourceUnitOfMeasureId = p.SourceUnitOfMeasureId,
+            SourceUnitOfMeasure = new Data.UnitOfMeasure.UnitOfMeasureModel()
+            {
+                Id = p.SourceUnitOfMeasure.Id,
+                Abbreviation = p.SourceUnitOfMeasure.Abbreviation,
+                ConversionToGramsRatio = p.SourceUnitOfMeasure.ConversionToGramsRatio,
+                Name = p.SourceUnitOfMeasure.Name
+            },
+            DestinationUnitOfMeasureId = p.DestinationUnitOfMeasureId,
+            DestinationUnitOfMeasure = new Data.UnitOfMeasure.UnitOfMeasureModel()
+            {
+                Id = p.DestinationUnitOfMeasure.Id,
+                Abbreviation = p.DestinationUnitOfMeasure.Abbreviation,
+                ConversionToGramsRatio = p.DestinationUnitOfMeasure.ConversionToGramsRatio,
+                Name = p.DestinationUnitOfMeasure.Name
+            },
+            ConversionRatio = p.ConversionRatio
+        });
+    }
+}

--- a/PriceTracker.Data/Entity/UnitOfMeasure.cs
+++ b/PriceTracker.Data/Entity/UnitOfMeasure.cs
@@ -11,8 +11,6 @@ internal class UnitOfMeasure
     public string Name { get; set; }
 
     public string Abbreviation { get; set; }
-
-    public decimal ConversionToGramsRatio { get; set; }
 }
 
 internal class UnitOfMeasureConfiguration : IEntityTypeConfiguration<UnitOfMeasure>
@@ -30,9 +28,6 @@ internal class UnitOfMeasureConfiguration : IEntityTypeConfiguration<UnitOfMeasu
         builder.Property(p => p.Abbreviation)
             .IsRequired(true)
             .HasMaxLength(8);
-
-        builder.Property(p => p.ConversionToGramsRatio)
-            .HasColumnType("decimal(9,5)");
     }
 }
 
@@ -43,8 +38,7 @@ internal static class UnitOfMeasureExtensions
         return entity == null ? null : new UnitOfMeasureModel()
         {
             Name = entity.Name,
-            Abbreviation = entity.Abbreviation,
-            ConversionToGramsRatio = entity.ConversionToGramsRatio
+            Abbreviation = entity.Abbreviation
         };
     }
 
@@ -54,8 +48,7 @@ internal static class UnitOfMeasureExtensions
         {
             Id = p.Id,
             Name = p.Name,
-            Abbreviation = p.Abbreviation,
-            ConversionToGramsRatio = p.ConversionToGramsRatio
+            Abbreviation = p.Abbreviation
         });
     }
 }

--- a/PriceTracker.Data/Migrations/20240318155657_Adds-Unit-Conversion.Designer.cs
+++ b/PriceTracker.Data/Migrations/20240318155657_Adds-Unit-Conversion.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using PriceTracker.Data;
 
@@ -11,9 +12,11 @@ using PriceTracker.Data;
 namespace PriceTracker.Data.Migrations
 {
     [DbContext(typeof(ApplicationDBContext))]
-    partial class AppDBContextModelSnapshot : ModelSnapshot
+    [Migration("20240318155657_Adds-Unit-Conversion")]
+    partial class AddsUnitConversion
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/PriceTracker.Data/Migrations/20240318155657_Adds-Unit-Conversion.cs
+++ b/PriceTracker.Data/Migrations/20240318155657_Adds-Unit-Conversion.cs
@@ -1,0 +1,58 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace PriceTracker.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddsUnitConversion : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "UnitConversion",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    SourceUnitOfMeasureId = table.Column<int>(type: "int", nullable: false),
+                    DestinationUnitOfMeasureId = table.Column<int>(type: "int", nullable: false),
+                    ConversionRatio = table.Column<decimal>(type: "decimal(9,5)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_UnitConversion", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_UnitConversion_UnitOfMeasure_DestinationUnitOfMeasureId",
+                        column: x => x.DestinationUnitOfMeasureId,
+                        principalTable: "UnitOfMeasure",
+                        principalColumn: "Id");
+                    table.ForeignKey(
+                        name: "FK_UnitConversion_UnitOfMeasure_SourceUnitOfMeasureId",
+                        column: x => x.SourceUnitOfMeasureId,
+                        principalTable: "UnitOfMeasure",
+                        principalColumn: "Id");
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UnitConversion_DestinationUnitOfMeasureId",
+                table: "UnitConversion",
+                column: "DestinationUnitOfMeasureId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UnitConversion_SourceUnitOfMeasureId_DestinationUnitOfMeasureId",
+                table: "UnitConversion",
+                columns: new[] { "SourceUnitOfMeasureId", "DestinationUnitOfMeasureId" },
+                unique: true)
+                .Annotation("SqlServer:Clustered", false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "UnitConversion");
+        }
+    }
+}

--- a/PriceTracker.Data/Migrations/20240319072019_Remove-UoM-ConvertRatio.Designer.cs
+++ b/PriceTracker.Data/Migrations/20240319072019_Remove-UoM-ConvertRatio.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using PriceTracker.Data;
 
@@ -11,9 +12,11 @@ using PriceTracker.Data;
 namespace PriceTracker.Data.Migrations
 {
     [DbContext(typeof(ApplicationDBContext))]
-    partial class AppDBContextModelSnapshot : ModelSnapshot
+    [Migration("20240319072019_Remove-UoM-ConvertRatio")]
+    partial class RemoveUoMConvertRatio
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/PriceTracker.Data/Migrations/20240319072019_Remove-UoM-ConvertRatio.cs
+++ b/PriceTracker.Data/Migrations/20240319072019_Remove-UoM-ConvertRatio.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace PriceTracker.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class RemoveUoMConvertRatio : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ConversionToGramsRatio",
+                table: "UnitOfMeasure");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<decimal>(
+                name: "ConversionToGramsRatio",
+                table: "UnitOfMeasure",
+                type: "decimal(9,5)",
+                nullable: false,
+                defaultValue: 0m);
+        }
+    }
+}

--- a/PriceTracker.Data/Services.cs
+++ b/PriceTracker.Data/Services.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 using PriceTracker.Data.PriceHistory.Behaviors;
 using PriceTracker.Data.Product.Behaviors;
 using PriceTracker.Data.Store.Behaviors;
+using PriceTracker.Data.UnitConversion.Behaviors;
 using PriceTracker.Data.UnitOfMeasure.Behaviors;
 using PriceTracker.Data.User;
 
@@ -39,7 +40,8 @@ public static class Services
             config.AddUnitOfMeasureBehaviors()
                   .AddProductBehaviors()
                   .AddStoreBehaviors()
-                  .AddPriceHistoryBehaviors();
+                  .AddPriceHistoryBehaviors()
+                  .AddUnitConversionBehaviors();
 
         });
 

--- a/PriceTracker.Data/UnitConversion/Behaviors/AddBehaviorService.cs
+++ b/PriceTracker.Data/UnitConversion/Behaviors/AddBehaviorService.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+
+namespace PriceTracker.Data.UnitConversion.Behaviors;
+
+internal static class AddBehaviorService
+{
+    public static MediatRServiceConfiguration AddUnitConversionBehaviors(this MediatRServiceConfiguration config)
+    {
+        config.AddBehavior<CreateValidationBehavior>(ServiceLifetime.Scoped);
+        config.AddBehavior<UpdateValidationBehavior>(ServiceLifetime.Scoped);
+
+        return config;
+    }
+}

--- a/PriceTracker.Data/UnitConversion/Behaviors/CreateValidationBehavior.cs
+++ b/PriceTracker.Data/UnitConversion/Behaviors/CreateValidationBehavior.cs
@@ -1,0 +1,63 @@
+﻿using PriceTracker.Data.Results;
+using PriceTracker.Data.UnitConversion.Commands;
+
+namespace PriceTracker.Data.UnitConversion.Behaviors;
+
+internal class CreateValidationBehavior : IPipelineBehavior<CreateUnitConversion, Result<UnitConversionModel>>
+{
+    private readonly ApplicationDBContext _dbContext;
+
+    private readonly ILogger<CreateValidationBehavior> _logger;
+
+    public CreateValidationBehavior(ApplicationDBContext dbContext, ILogger<CreateValidationBehavior> logger)
+    {
+        _dbContext = dbContext;
+        _logger = logger;
+    }
+
+    public async Task<Result<UnitConversionModel>> Handle(CreateUnitConversion request, RequestHandlerDelegate<Result<UnitConversionModel>> next, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var result = Result.BadRequest<UnitConversionModel>();
+
+            // Check for ratio greater than zero;
+            if (request.ConversionRatio <= 0)
+            {
+                result.AddError(nameof(request.ConversionRatio), $"The value for {nameof(request.ConversionRatio)} must be greater than zero (0).");
+            }
+
+            // Check the source and destination UnitOfMeasures exist.
+            if (!await _dbContext.UnitOfMeasures.AnyAsync(p => p.Id.Equals(request.SourceUnitOfMeasureId), cancellationToken))
+            {
+                result.AddError(nameof(request.SourceUnitOfMeasureId), $"The {nameof(request.SourceUnitOfMeasureId)} specified was not found.");
+            }
+
+            if (!await _dbContext.UnitOfMeasures.AnyAsync(p => p.Id.Equals(request.DestinationUnitOfMeasureId), cancellationToken))
+            {
+                result.AddError(nameof(request.DestinationUnitOfMeasureId), $"The {nameof(request.DestinationUnitOfMeasureId)} specified was not found.");
+            }
+
+            // Check that there is not already a UnitConversion for this source/destination pair.
+            if (await _dbContext.UnitConversions
+                .CountAsync(p => p.SourceUnitOfMeasureId.Equals(request.SourceUnitOfMeasureId) &&
+                            p.DestinationUnitOfMeasureId.Equals(request.DestinationUnitOfMeasureId), cancellationToken) > 0)
+            {
+                result.AddError(string.Empty, $"A UnitConversion already exists for this {nameof(request.SourceUnitOfMeasureId)} and {nameof(request.DestinationUnitOfMeasureId)}.");
+            }
+
+            if (result.HasErrors)
+            {
+                return result;
+            }
+
+            return await next();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unexpected error.");
+
+            return Result.ServerError<UnitConversionModel>();
+        }
+    }
+}

--- a/PriceTracker.Data/UnitConversion/Behaviors/UpdateValidationBehavior.cs
+++ b/PriceTracker.Data/UnitConversion/Behaviors/UpdateValidationBehavior.cs
@@ -1,0 +1,64 @@
+﻿using PriceTracker.Data.Results;
+using PriceTracker.Data.UnitConversion.Commands;
+
+namespace PriceTracker.Data.UnitConversion.Behaviors;
+
+internal class UpdateValidationBehavior : IPipelineBehavior<UpdateUnitConversion, Result<UnitConversionModel>>
+{
+    private readonly ApplicationDBContext _dbContext;
+
+    private readonly ILogger<UpdateValidationBehavior> _logger;
+
+    public UpdateValidationBehavior(ApplicationDBContext dbContext, ILogger<UpdateValidationBehavior> logger)
+    {
+        _dbContext = dbContext;
+        _logger = logger;
+    }
+
+    public async Task<Result<UnitConversionModel>> Handle(UpdateUnitConversion request, RequestHandlerDelegate<Result<UnitConversionModel>> next, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var result = Result.BadRequest<UnitConversionModel>();
+
+            // Check for ratio greater than zero;
+            if (request.ConversionRatio <= 0)
+            {
+                result.AddError(nameof(request.ConversionRatio), $"The value for {nameof(request.ConversionRatio)} must be greater than zero (0).");
+            }
+
+            // Check the source and destination UnitOfMeasures exist.
+            if (!await _dbContext.UnitOfMeasures.AnyAsync(p => p.Id.Equals(request.SourceUnitOfMeasureId), cancellationToken))
+            {
+                result.AddError(nameof(request.SourceUnitOfMeasureId), $"The {nameof(request.SourceUnitOfMeasureId)} specified was not found.");
+            }
+
+            if (!await _dbContext.UnitOfMeasures.AnyAsync(p => p.Id.Equals(request.DestinationUnitOfMeasureId), cancellationToken))
+            {
+                result.AddError(nameof(request.DestinationUnitOfMeasureId), $"The {nameof(request.DestinationUnitOfMeasureId)} specified was not found.");
+            }
+
+            // Check that there is not already a UnitConversion for this source/destination pair that isn't this id.
+            if (await _dbContext.UnitConversions
+                .CountAsync(p => p.SourceUnitOfMeasureId.Equals(request.SourceUnitOfMeasureId) &&
+                            p.DestinationUnitOfMeasureId.Equals(request.DestinationUnitOfMeasureId) &&
+                            !p.Id.Equals(request.Id), cancellationToken) > 0)
+            {
+                result.AddError(string.Empty, $"A UnitConversion already exists for this {nameof(request.SourceUnitOfMeasureId)} and {nameof(request.DestinationUnitOfMeasureId)}.");
+            }
+
+            if (result.HasErrors)
+            {
+                return result;
+            }
+
+            return await next();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unexpected error.");
+
+            return Result.ServerError<UnitConversionModel>();
+        }
+    }
+}

--- a/PriceTracker.Data/UnitConversion/Commands/CreateUnitConversion.cs
+++ b/PriceTracker.Data/UnitConversion/Commands/CreateUnitConversion.cs
@@ -1,0 +1,53 @@
+﻿using PriceTracker.Data.Entity;
+using PriceTracker.Data.Results;
+
+namespace PriceTracker.Data.UnitConversion.Commands;
+
+public class CreateUnitConversion : IRequest<Result<UnitConversionModel>>
+{
+    public int SourceUnitOfMeasureId { get; set; }
+
+    public int DestinationUnitOfMeasureId { get; set; }
+
+    public decimal ConversionRatio { get; set; }
+}
+
+internal class CreateUnitConversionHandler : IRequestHandler<CreateUnitConversion, Result<UnitConversionModel>>
+{
+    private readonly ApplicationDBContext _dbContext;
+
+    private readonly ILogger<CreateUnitConversionHandler> _logger;
+
+    public CreateUnitConversionHandler(ApplicationDBContext dbContext, ILogger<CreateUnitConversionHandler> logger)
+    {
+        _dbContext = dbContext;
+        _logger = logger;
+    }
+
+    public async Task<Result<UnitConversionModel>> Handle(CreateUnitConversion request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var entity = _dbContext.UnitConversions.Add(new Entity.UnitConversion()
+            {
+                SourceUnitOfMeasureId = request.SourceUnitOfMeasureId,
+                DestinationUnitOfMeasureId = request.DestinationUnitOfMeasureId,
+                ConversionRatio = request.ConversionRatio
+            });
+
+            await _dbContext.SaveChangesAsync(cancellationToken);
+
+            // Load the referenced uoms.
+            await entity.Reference(p => p.SourceUnitOfMeasure).LoadAsync();
+            await entity.Reference(p => p.DestinationUnitOfMeasure).LoadAsync();
+
+            return Result.Ok(entity.Entity.AsModel());
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unexpected error.");
+
+            return Result.ServerError<UnitConversionModel>();
+        }
+    }
+}

--- a/PriceTracker.Data/UnitConversion/Commands/DeleteUnitConversion.cs
+++ b/PriceTracker.Data/UnitConversion/Commands/DeleteUnitConversion.cs
@@ -1,0 +1,46 @@
+﻿using PriceTracker.Data.Results;
+
+namespace PriceTracker.Data.UnitConversion.Commands;
+
+public class DeleteUnitConversion : IRequest<Result<Unit>>
+{
+    public int Id { get; set; }
+}
+
+internal class DeleteUnitConversionHandler : IRequestHandler<DeleteUnitConversion, Result<Unit>>
+{
+    private readonly ApplicationDBContext _dbContext;
+
+    private readonly ILogger<DeleteUnitConversionHandler> _logger;
+
+    public DeleteUnitConversionHandler(ApplicationDBContext dbContext, ILogger<DeleteUnitConversionHandler> logger)
+    {
+        _dbContext = dbContext;
+        _logger = logger;
+    }
+
+    public async Task<Result<Unit>> Handle(DeleteUnitConversion request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var entity = await _dbContext.UnitConversions.FindAsync(request.Id);
+
+            if (entity == null)
+            {
+                return Result.NotFound<Unit>();
+            }
+
+            _dbContext.UnitConversions.Remove(entity);
+
+            await _dbContext.SaveChangesAsync(cancellationToken);
+
+            return Result.Ok<Unit>();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unexpected error.");
+
+            return Result.ServerError<Unit>();
+        }
+    }
+}

--- a/PriceTracker.Data/UnitConversion/Commands/UpdateUnitConversion.cs
+++ b/PriceTracker.Data/UnitConversion/Commands/UpdateUnitConversion.cs
@@ -1,0 +1,62 @@
+﻿using PriceTracker.Data.Entity;
+using PriceTracker.Data.Results;
+
+namespace PriceTracker.Data.UnitConversion.Commands;
+
+public class UpdateUnitConversion : IRequest<Result<UnitConversionModel>>
+{
+    public int Id { get; set; }
+
+    public int SourceUnitOfMeasureId { get; set; }
+
+    public int DestinationUnitOfMeasureId { get; set; }
+
+    public decimal ConversionRatio { get; set; }
+}
+
+internal class UpdateUnitConversionHandler : IRequestHandler<UpdateUnitConversion, Result<UnitConversionModel>>
+{
+    private readonly ApplicationDBContext _dbContext;
+
+    private readonly ILogger<UpdateUnitConversionHandler> _logger;
+
+    public UpdateUnitConversionHandler(ApplicationDBContext dbContext, ILogger<UpdateUnitConversionHandler> logger)
+    {
+        _dbContext = dbContext;
+        _logger = logger;
+    }
+
+    public async Task<Result<UnitConversionModel>> Handle(UpdateUnitConversion request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var entity = await _dbContext.UnitConversions
+                .Include(p => p.SourceUnitOfMeasure)
+                .Include(p => p.DestinationUnitOfMeasure)
+                .AsTracking()
+                .SingleOrDefaultAsync(p => p.Id.Equals(request.Id), cancellationToken);
+
+            if (entity == null)
+            {
+                return Result.NotFound<UnitConversionModel>();
+            }
+
+            entity.SourceUnitOfMeasureId = request.SourceUnitOfMeasureId;
+            entity.DestinationUnitOfMeasureId = request.DestinationUnitOfMeasureId;
+            entity.ConversionRatio = request.ConversionRatio;
+
+            await _dbContext.SaveChangesAsync(cancellationToken);
+
+            // Do we need to refresh the entity details?
+
+            return Result.Ok(entity.AsModel());
+
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unexpected error.");
+
+            return Result.ServerError<UnitConversionModel>();
+        }
+    }
+}

--- a/PriceTracker.Data/UnitConversion/Queries/GetUnitConversionById.cs
+++ b/PriceTracker.Data/UnitConversion/Queries/GetUnitConversionById.cs
@@ -1,0 +1,47 @@
+﻿using PriceTracker.Data.Entity;
+using PriceTracker.Data.Results;
+using System.Linq;
+
+namespace PriceTracker.Data.UnitConversion.Queries;
+
+public class GetUnitConversionById : IRequest<Result<UnitConversionModel>>
+{
+    public int Id { get; set; }
+}
+
+internal class GetUnitConversionByIdHandler : IRequestHandler<GetUnitConversionById, Result<UnitConversionModel>>
+{
+    private readonly ApplicationDBContext _dbContext;
+
+    private readonly ILogger<GetUnitConversionByIdHandler> _logger;
+
+    public GetUnitConversionByIdHandler(ApplicationDBContext dbContext, ILogger<GetUnitConversionByIdHandler> logger)
+    {
+        _dbContext = dbContext;
+        _logger = logger;
+    }
+
+    public async Task<Result<UnitConversionModel>> Handle(GetUnitConversionById request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var entity = await _dbContext.UnitConversions
+                .Where(p => p.Id.Equals(request.Id))
+                .ProjectToModel()
+                .SingleOrDefaultAsync(cancellationToken);
+
+            if (entity == null)
+            {
+                return Result.NotFound<UnitConversionModel>();
+            }
+
+            return Result.Ok(entity);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unexpected error.");
+
+            return Result.ServerError<UnitConversionModel>();
+        }
+    }
+}

--- a/PriceTracker.Data/UnitConversion/Queries/GetUnitConversionByUnitOfMeasureIds.cs
+++ b/PriceTracker.Data/UnitConversion/Queries/GetUnitConversionByUnitOfMeasureIds.cs
@@ -1,0 +1,49 @@
+﻿using PriceTracker.Data.Entity;
+using PriceTracker.Data.Results;
+using System.Linq;
+
+namespace PriceTracker.Data.UnitConversion.Queries;
+
+public class GetUnitConversionByUnitOfMeasureIds : IRequest<Result<UnitConversionModel>>
+{
+    public int SourceUnitOfMeasureId { get; set; }
+
+    public int DestinationUnitOfMeasureId { get; set; }
+}
+
+internal class GetUnitConversionByUnitOfMeasureIdsHandler : IRequestHandler<GetUnitConversionByUnitOfMeasureIds, Result<UnitConversionModel>>
+{
+    private readonly ApplicationDBContext _dbContext;
+
+    private readonly ILogger<GetUnitConversionByUnitOfMeasureIdsHandler> _logger;
+
+    public GetUnitConversionByUnitOfMeasureIdsHandler(ApplicationDBContext dbContext, ILogger<GetUnitConversionByUnitOfMeasureIdsHandler> logger)
+    {
+        _dbContext = dbContext;
+        _logger = logger;
+    }
+
+    public async Task<Result<UnitConversionModel>> Handle(GetUnitConversionByUnitOfMeasureIds request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var entity = await _dbContext.UnitConversions
+                .Where(p => p.SourceUnitOfMeasureId.Equals(request.SourceUnitOfMeasureId) && p.DestinationUnitOfMeasureId.Equals(request.DestinationUnitOfMeasureId))
+                .ProjectToModel()
+                .SingleOrDefaultAsync(cancellationToken);
+
+            if (entity == null)
+            {
+                return Result.NotFound<UnitConversionModel>();
+            }
+
+            return Result.Ok(entity);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unexpected error.");
+
+            return Result.ServerError<UnitConversionModel>();
+        }
+    }
+}

--- a/PriceTracker.Data/UnitConversion/Queries/GetUnitConversionsByDestinationUoM.cs
+++ b/PriceTracker.Data/UnitConversion/Queries/GetUnitConversionsByDestinationUoM.cs
@@ -1,0 +1,43 @@
+﻿using PriceTracker.Data.Entity;
+using PriceTracker.Data.Results;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PriceTracker.Data.UnitConversion.Queries;
+
+public class GetUnitConversionsByDestinationUoM : IRequest<Result<List<UnitConversionModel>>>
+{
+    public int DestinationUnitOfMeasureId { get; set; }
+}
+
+internal class GetUnitConversionsByDestinationUoMHandler : IRequestHandler<GetUnitConversionsByDestinationUoM, Result<List<UnitConversionModel>>>
+{
+    private readonly ApplicationDBContext _dbContext;
+
+    private readonly ILogger<GetUnitConversionsByDestinationUoMHandler> _logger;
+
+    public GetUnitConversionsByDestinationUoMHandler(ApplicationDBContext dbContext, ILogger<GetUnitConversionsByDestinationUoMHandler> logger)
+    {
+        _dbContext = dbContext;
+        _logger = logger;
+    }
+
+    public async Task<Result<List<UnitConversionModel>>> Handle(GetUnitConversionsByDestinationUoM request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var entities = await _dbContext.UnitConversions
+                .Where(p => p.DestinationUnitOfMeasureId.Equals(request.DestinationUnitOfMeasureId))
+                .ProjectToModel()
+                .ToListAsync(cancellationToken);
+
+            return Result.Ok(entities);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unexpected error.");
+
+            return Result.ServerError<List<UnitConversionModel>>();
+        }
+    }
+}

--- a/PriceTracker.Data/UnitConversion/Queries/GetUnitConversionsBySourceUoM.cs
+++ b/PriceTracker.Data/UnitConversion/Queries/GetUnitConversionsBySourceUoM.cs
@@ -1,0 +1,43 @@
+﻿using PriceTracker.Data.Entity;
+using PriceTracker.Data.Results;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PriceTracker.Data.UnitConversion.Queries;
+
+public class GetUnitConversionsBySourceUoM : IRequest<Result<List<UnitConversionModel>>>
+{
+    public int SourceUnitOfMeasureId { get; set; }
+}
+
+internal class GetUnitConversionsBySourceUoMHandler : IRequestHandler<GetUnitConversionsBySourceUoM, Result<List<UnitConversionModel>>>
+{
+    private readonly ApplicationDBContext _dbContext;
+
+    private readonly ILogger<GetUnitConversionsBySourceUoMHandler> _logger;
+
+    public GetUnitConversionsBySourceUoMHandler(ApplicationDBContext dbContext, ILogger<GetUnitConversionsBySourceUoMHandler> logger)
+    {
+        _dbContext = dbContext;
+        _logger = logger;
+    }
+
+    public async Task<Result<List<UnitConversionModel>>> Handle(GetUnitConversionsBySourceUoM request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var entities = await _dbContext.UnitConversions
+                .Where(p => p.SourceUnitOfMeasureId.Equals(request.SourceUnitOfMeasureId))
+                .ProjectToModel()
+                .ToListAsync(cancellationToken);
+
+            return Result.Ok(entities);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unexpected error.");
+
+            return Result.ServerError<List<UnitConversionModel>>();
+        }
+    }
+}

--- a/PriceTracker.Data/UnitConversion/UnitConversionModel.cs
+++ b/PriceTracker.Data/UnitConversion/UnitConversionModel.cs
@@ -1,0 +1,16 @@
+﻿using PriceTracker.Data.UnitOfMeasure;
+
+namespace PriceTracker.Data.UnitConversion;
+
+public class UnitConversionModel
+{
+    public int SourceUnitOfMeasureId { get; set; }
+
+    public UnitOfMeasureModel SourceUnitOfMeasure { get; set; }
+
+    public int DestinationUnitOfMeasureId { get; set; }
+
+    public UnitOfMeasureModel DestinationUnitOfMeasure { get; set; }
+
+    public decimal ConversionRatio { get; set; }
+}

--- a/PriceTracker.Data/UnitOfMeasure/Behaviors/CreateValidationBehavior.cs
+++ b/PriceTracker.Data/UnitOfMeasure/Behaviors/CreateValidationBehavior.cs
@@ -44,12 +44,6 @@ internal class CreateValidationBehavior : IPipelineBehavior<CreateUnitOfMeasure,
                 result.AddError(nameof(request.Abbreviation), $"The value '{request.Abbreviation}' for {nameof(request.Abbreviation)} already exists.");
             }
 
-            // Check that Conversion ratio is greater than zero.
-            if (request.ConversionToGramsRatio <= 0)
-            {
-                result.AddError(nameof(request.ConversionToGramsRatio), $"The value for {nameof(request.ConversionToGramsRatio)} must be greater than zero (0).");
-            }
-
             if (result.HasErrors)
             {
                 return result;

--- a/PriceTracker.Data/UnitOfMeasure/Behaviors/UpdateValidationBehavior.cs
+++ b/PriceTracker.Data/UnitOfMeasure/Behaviors/UpdateValidationBehavior.cs
@@ -45,13 +45,6 @@ internal class UpdateValidationBehavior : IPipelineBehavior<UpdateUnitOfMeasure,
                 result.AddError(nameof(request.Abbreviation), $"The value '{request.Abbreviation}' for {nameof(request.Abbreviation)} already exists.");
             }
 
-            // Check that Conversion ratio is greater than zero.
-            if (request.ConversionToGramsRatio <= 0)
-            {
-                result.AddError(nameof(request.ConversionToGramsRatio), $"The value for {nameof(request.ConversionToGramsRatio)} must be greater than zero (0).");
-            }
-
-
             if (result.HasErrors)
             {
                 return result;

--- a/PriceTracker.Data/UnitOfMeasure/Commands/CreateUnitOfMeasure.cs
+++ b/PriceTracker.Data/UnitOfMeasure/Commands/CreateUnitOfMeasure.cs
@@ -8,8 +8,6 @@ public class CreateUnitOfMeasure : IRequest<Result<UnitOfMeasureModel>>
     public string Name { get; set; }
 
     public string Abbreviation { get; set; }
-
-    public decimal ConversionToGramsRatio { get; set; }
 }
 
 internal class CreateUnitOfMeasureHandler : IRequestHandler<CreateUnitOfMeasure, Result<UnitOfMeasureModel>>
@@ -31,8 +29,7 @@ internal class CreateUnitOfMeasureHandler : IRequestHandler<CreateUnitOfMeasure,
             var entity = _dbContext.UnitOfMeasures.Add(new Entity.UnitOfMeasure()
             {
                 Name = request.Name,
-                Abbreviation = request.Abbreviation,
-                ConversionToGramsRatio = request.ConversionToGramsRatio
+                Abbreviation = request.Abbreviation
             });
 
             await _dbContext.SaveChangesAsync(cancellationToken);

--- a/PriceTracker.Data/UnitOfMeasure/Commands/UpdateUnitOfMeasure.cs
+++ b/PriceTracker.Data/UnitOfMeasure/Commands/UpdateUnitOfMeasure.cs
@@ -10,8 +10,6 @@ public class UpdateUnitOfMeasure : IRequest<Result<UnitOfMeasureModel>>
     public string Name { get; set; }
 
     public string Abbreviation { get; set; }
-
-    public decimal ConversionToGramsRatio { get; set; }
 }
 
 internal class UpdateUnitOfMeasureHandler : IRequestHandler<UpdateUnitOfMeasure, Result<UnitOfMeasureModel>>
@@ -39,7 +37,6 @@ internal class UpdateUnitOfMeasureHandler : IRequestHandler<UpdateUnitOfMeasure,
 
             entity.Name = request.Name;
             entity.Abbreviation = request.Abbreviation;
-            entity.ConversionToGramsRatio = request.ConversionToGramsRatio;
 
             await _dbContext.SaveChangesAsync(cancellationToken);
 

--- a/PriceTracker.Data/UnitOfMeasure/Queries/GetUnitOfMeasuresAsDict.cs
+++ b/PriceTracker.Data/UnitOfMeasure/Queries/GetUnitOfMeasuresAsDict.cs
@@ -30,8 +30,7 @@ internal class GetUnitOfMeasuresAsDictHandler : IRequestHandler<GetUnitOfMeasure
                                    {
                                        Id = p.Id,
                                        Name = p.Name,
-                                       Abbreviation = p.Abbreviation,
-                                       ConversionToGramsRatio = p.ConversionToGramsRatio
+                                       Abbreviation = p.Abbreviation
                                    }, cancellationToken);
 
             return Result.Ok(entities);

--- a/PriceTracker.Data/UnitOfMeasure/UnitOfMeasureModel.cs
+++ b/PriceTracker.Data/UnitOfMeasure/UnitOfMeasureModel.cs
@@ -16,8 +16,4 @@ public class UnitOfMeasureModel
     [Required]
     [MaxLength(8)]
     public string Abbreviation { get; set; }
-
-    [Display(Name = "Conversion to Grams Ratio")]
-    [Required]
-    public decimal ConversionToGramsRatio { get; set; }
 }

--- a/PriceTracker.Testing/PriceHistory/Commands/UpdatePriceHistoryTests.cs
+++ b/PriceTracker.Testing/PriceHistory/Commands/UpdatePriceHistoryTests.cs
@@ -24,8 +24,8 @@ public class UpdatePriceHistoryTests : IAsyncLifetime, IClassFixture<BaseTestFix
         // Seed data
         uoms = new List<Data.Entity.UnitOfMeasure>()
         {
-            new Data.Entity.UnitOfMeasure(){ Name = "ounce", Abbreviation = "oz", ConversionToGramsRatio = 28.5m },
-            new Data.Entity.UnitOfMeasure(){ Name = "gram", Abbreviation = "g", ConversionToGramsRatio = 1.0m }
+            new Data.Entity.UnitOfMeasure(){ Name = "ounce", Abbreviation = "oz" },
+            new Data.Entity.UnitOfMeasure(){ Name = "gram", Abbreviation = "g" }
         };
         await _fixture.AddRangeAsync(uoms);
 

--- a/PriceTracker.Testing/Product/Commands/UpdateProductTests.cs
+++ b/PriceTracker.Testing/Product/Commands/UpdateProductTests.cs
@@ -21,8 +21,8 @@ public class UpdateProductTests : IAsyncLifetime, IClassFixture<BaseTestFixture>
         // Seed data
         uoms = new List<Data.Entity.UnitOfMeasure>()
         {
-            new Data.Entity.UnitOfMeasure(){ Name = "ounce", Abbreviation = "oz", ConversionToGramsRatio = 28.5m },
-            new Data.Entity.UnitOfMeasure(){ Name = "gram", Abbreviation = "g", ConversionToGramsRatio = 1.0m }
+            new Data.Entity.UnitOfMeasure(){ Name = "ounce", Abbreviation = "oz" },
+            new Data.Entity.UnitOfMeasure(){ Name = "gram", Abbreviation = "g" }
         };
         await _fixture.AddRangeAsync(uoms);
 

--- a/PriceTracker.Testing/UnitConversion/Commands/CreateUnitConversionTests.cs
+++ b/PriceTracker.Testing/UnitConversion/Commands/CreateUnitConversionTests.cs
@@ -9,8 +9,8 @@ public class CreateUnitConversionTests : IAsyncLifetime, IClassFixture<BaseTestF
 
     private readonly List<Data.Entity.UnitOfMeasure> _uoms = new List<Data.Entity.UnitOfMeasure>()
     {
-        new Data.Entity.UnitOfMeasure() { Name = "milliliter", Abbreviation = "ml", ConversionToGramsRatio = 1.0m },
-        new Data.Entity.UnitOfMeasure() { Name = "ounce", Abbreviation = "oz", ConversionToGramsRatio = 28.35m }
+        new Data.Entity.UnitOfMeasure() { Name = "milliliter", Abbreviation = "ml" },
+        new Data.Entity.UnitOfMeasure() { Name = "ounce", Abbreviation = "oz" }
     };
 
     public CreateUnitConversionTests(BaseTestFixture fixture)

--- a/PriceTracker.Testing/UnitConversion/Commands/CreateUnitConversionTests.cs
+++ b/PriceTracker.Testing/UnitConversion/Commands/CreateUnitConversionTests.cs
@@ -1,0 +1,125 @@
+﻿using PriceTracker.Data.UnitConversion.Commands;
+using System.Collections.Generic;
+
+namespace PriceTracker.Testing.UnitConversion.Commands;
+
+public class CreateUnitConversionTests : IAsyncLifetime, IClassFixture<BaseTestFixture>
+{
+    private readonly BaseTestFixture _fixture;
+
+    private readonly List<Data.Entity.UnitOfMeasure> _uoms = new List<Data.Entity.UnitOfMeasure>()
+    {
+        new Data.Entity.UnitOfMeasure() { Name = "milliliter", Abbreviation = "ml", ConversionToGramsRatio = 1.0m },
+        new Data.Entity.UnitOfMeasure() { Name = "ounce", Abbreviation = "oz", ConversionToGramsRatio = 28.35m }
+    };
+
+    public CreateUnitConversionTests(BaseTestFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _fixture.AddRangeAsync(_uoms);
+    }
+
+    [Fact]
+    public async Task Create_With_Valid_Values_Is_Possible()
+    {
+        // Arrange
+        var createCommand = new CreateUnitConversion() { SourceUnitOfMeasureId = _uoms[0].Id, DestinationUnitOfMeasureId = _uoms[1].Id, ConversionRatio = 30m };
+
+        // Act
+        var result = await _fixture.SendAsync(createCommand);
+
+        // Assert
+        result.WasSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value.SourceUnitOfMeasureId.Should().Be(createCommand.SourceUnitOfMeasureId);
+        result.Value.SourceUnitOfMeasure.Should().NotBeNull();
+        result.Value.DestinationUnitOfMeasureId.Should().Be(createCommand.DestinationUnitOfMeasureId);
+        result.Value.DestinationUnitOfMeasure.Should().NotBeNull();
+        result.Value.ConversionRatio.Should().Be(createCommand.ConversionRatio);
+    }
+
+    [Fact]
+    public async Task Create_With_Duplicate_Source_And_Destination_Is_Not_Possible()
+    {
+        // Arrange
+        await _fixture.AddAsync(new Data.Entity.UnitConversion() { SourceUnitOfMeasureId = _uoms[0].Id, DestinationUnitOfMeasureId = _uoms[1].Id, ConversionRatio = 1m });
+        var command = new CreateUnitConversion() { SourceUnitOfMeasureId = _uoms[0].Id, DestinationUnitOfMeasureId = _uoms[1].Id, ConversionRatio = 5m };
+
+        // Act
+        var result = await _fixture.SendAsync(command);
+
+        // Assert
+        result.WasFailure.Should().BeTrue();
+        result.StatusCode.Should().Be(System.Net.HttpStatusCode.BadRequest);
+        result.Errors.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task Create_With_Negative_ConversionRatio_Is_Not_Possible()
+    {
+        // Arrange
+        var command = new CreateUnitConversion() { SourceUnitOfMeasureId = _uoms[0].Id, DestinationUnitOfMeasureId = _uoms[1].Id, ConversionRatio = -5m };
+
+        // Act
+        var result = await _fixture.SendAsync(command);
+
+        // Assert
+        result.WasFailure.Should().BeTrue();
+        result.StatusCode.Should().Be(System.Net.HttpStatusCode.BadRequest);
+        result.Errors.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task Create_With_Zero_ConversionRatio_Is_Not_Possible()
+    {
+        // Arrange
+        var command = new CreateUnitConversion() { SourceUnitOfMeasureId = _uoms[0].Id, DestinationUnitOfMeasureId = _uoms[1].Id, ConversionRatio = 0m };
+
+        // Act
+        var result = await _fixture.SendAsync(command);
+
+        // Assert
+        result.WasFailure.Should().BeTrue();
+        result.StatusCode.Should().Be(System.Net.HttpStatusCode.BadRequest);
+        result.Errors.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task Create_With_Invalid_SourceUnitOfMeasureId_Is_Not_Possible()
+    {
+        // Arrange
+        var command = new CreateUnitConversion() { SourceUnitOfMeasureId = 0, DestinationUnitOfMeasureId = _uoms[1].Id, ConversionRatio = 5m };
+
+        // Act
+        var result = await _fixture.SendAsync(command);
+
+        // Assert
+        result.WasFailure.Should().BeTrue();
+        result.StatusCode.Should().Be(System.Net.HttpStatusCode.BadRequest);
+        result.Errors.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task Create_With_Invalid_DestinationUnitOfMeasureId_Is_Not_Possible()
+    {
+        // Arrange
+        var command = new CreateUnitConversion() { SourceUnitOfMeasureId = _uoms[0].Id, DestinationUnitOfMeasureId = 0, ConversionRatio = 5m };
+
+        // Act
+        var result = await _fixture.SendAsync(command);
+
+        // Assert
+        result.WasFailure.Should().BeTrue();
+        result.StatusCode.Should().Be(System.Net.HttpStatusCode.BadRequest);
+        result.Errors.Should().HaveCount(1);
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _fixture.ResetDatabase();
+    }
+}

--- a/PriceTracker.Testing/UnitConversion/Commands/DeleteUnitConversionTests.cs
+++ b/PriceTracker.Testing/UnitConversion/Commands/DeleteUnitConversionTests.cs
@@ -21,8 +21,8 @@ public class DeleteUnitConversionTests : IAsyncLifetime, IClassFixture<BaseTestF
         // Seed data
         _uoms = new List<Data.Entity.UnitOfMeasure>()
         {
-            new Data.Entity.UnitOfMeasure(){ Name = "ounce", Abbreviation = "oz", ConversionToGramsRatio = 5m },
-            new Data.Entity.UnitOfMeasure(){Name= "pound", Abbreviation = "lbs", ConversionToGramsRatio = 1m }
+            new Data.Entity.UnitOfMeasure(){ Name = "ounce", Abbreviation = "oz" },
+            new Data.Entity.UnitOfMeasure(){Name= "pound", Abbreviation = "lbs" }
         };
         await _fixture.AddRangeAsync(_uoms);
 

--- a/PriceTracker.Testing/UnitConversion/Commands/DeleteUnitConversionTests.cs
+++ b/PriceTracker.Testing/UnitConversion/Commands/DeleteUnitConversionTests.cs
@@ -1,0 +1,63 @@
+﻿using PriceTracker.Data.UnitConversion.Commands;
+using System.Collections.Generic;
+
+namespace PriceTracker.Testing.UnitConversion.Commands;
+
+public class DeleteUnitConversionTests : IAsyncLifetime, IClassFixture<BaseTestFixture>
+{
+    private readonly BaseTestFixture _fixture;
+
+    private List<Data.Entity.UnitOfMeasure> _uoms;
+
+    private Data.Entity.UnitConversion _conversion;
+
+    public DeleteUnitConversionTests(BaseTestFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async Task InitializeAsync()
+    {
+        // Seed data
+        _uoms = new List<Data.Entity.UnitOfMeasure>()
+        {
+            new Data.Entity.UnitOfMeasure(){ Name = "ounce", Abbreviation = "oz", ConversionToGramsRatio = 5m },
+            new Data.Entity.UnitOfMeasure(){Name= "pound", Abbreviation = "lbs", ConversionToGramsRatio = 1m }
+        };
+        await _fixture.AddRangeAsync(_uoms);
+
+        _conversion = new Data.Entity.UnitConversion() { SourceUnitOfMeasureId = _uoms[0].Id, DestinationUnitOfMeasureId = _uoms[1].Id, ConversionRatio = 1.0m };
+        await _fixture.AddAsync(_conversion);
+    }
+
+    [Fact]
+    public async Task Delete_With_Valid_Id_Is_Possible()
+    {
+        // Assert
+        var command = new DeleteUnitConversion() { Id = _conversion.Id };
+
+        // Act
+        var result = await _fixture.SendAsync(command);
+
+        // Assert
+        result.WasSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Delete_With_Invalid_Id_Is_Not_Possible()
+    {
+        // Assert
+        var command = new DeleteUnitConversion() { Id = 0 };
+
+        // Act
+        var result = await _fixture.SendAsync(command);
+
+        // Assert
+        result.WasSuccess.Should().BeFalse();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _fixture.ResetDatabase();
+    }
+}

--- a/PriceTracker.Testing/UnitConversion/Commands/UpdateUnitConversionTests.cs
+++ b/PriceTracker.Testing/UnitConversion/Commands/UpdateUnitConversionTests.cs
@@ -11,8 +11,8 @@ public class UpdateUnitConversionTests : IAsyncLifetime, IClassFixture<BaseTestF
 
     private readonly List<Data.Entity.UnitOfMeasure> _uoms = new List<Data.Entity.UnitOfMeasure>()
     {
-        new Data.Entity.UnitOfMeasure() { Name = "milliliter", Abbreviation = "ml", ConversionToGramsRatio = 1.0m },
-        new Data.Entity.UnitOfMeasure() { Name = "ounce", Abbreviation = "oz", ConversionToGramsRatio = 28.35m }
+        new Data.Entity.UnitOfMeasure() { Name = "milliliter", Abbreviation = "ml" },
+        new Data.Entity.UnitOfMeasure() { Name = "ounce", Abbreviation = "oz" }
     };
 
     public UpdateUnitConversionTests(BaseTestFixture fixture)

--- a/PriceTracker.Testing/UnitConversion/Commands/UpdateUnitConversionTests.cs
+++ b/PriceTracker.Testing/UnitConversion/Commands/UpdateUnitConversionTests.cs
@@ -1,0 +1,132 @@
+﻿using PriceTracker.Data.UnitConversion.Commands;
+using System.Collections.Generic;
+
+namespace PriceTracker.Testing.UnitConversion.Commands;
+
+public class UpdateUnitConversionTests : IAsyncLifetime, IClassFixture<BaseTestFixture>
+{
+    private readonly BaseTestFixture _fixture;
+
+    private Data.Entity.UnitConversion _conversion;
+
+    private readonly List<Data.Entity.UnitOfMeasure> _uoms = new List<Data.Entity.UnitOfMeasure>()
+    {
+        new Data.Entity.UnitOfMeasure() { Name = "milliliter", Abbreviation = "ml", ConversionToGramsRatio = 1.0m },
+        new Data.Entity.UnitOfMeasure() { Name = "ounce", Abbreviation = "oz", ConversionToGramsRatio = 28.35m }
+    };
+
+    public UpdateUnitConversionTests(BaseTestFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _fixture.AddRangeAsync(_uoms);
+        _conversion = new Data.Entity.UnitConversion() { SourceUnitOfMeasureId = _uoms[0].Id, DestinationUnitOfMeasureId = _uoms[1].Id, ConversionRatio = 1.0m };
+        await _fixture.AddAsync(_conversion);
+    }
+
+    [Fact]
+    public async Task Update_With_Valid_Values_Is_Possible()
+    {
+        // Arrange
+        var command = new UpdateUnitConversion() { Id = _conversion.Id, SourceUnitOfMeasureId = _uoms[1].Id, DestinationUnitOfMeasureId = _uoms[0].Id, ConversionRatio = 2.0m };
+
+        // Act
+        var result = await _fixture.SendAsync(command);
+
+        // Assert
+        result.WasSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value.SourceUnitOfMeasureId.Should().Be(command.SourceUnitOfMeasureId);
+        result.Value.SourceUnitOfMeasure.Should().NotBeNull();
+        result.Value.SourceUnitOfMeasure.Name.Should().Be(_uoms[1].Name);
+        result.Value.DestinationUnitOfMeasureId.Should().Be(command.DestinationUnitOfMeasureId);
+        result.Value.DestinationUnitOfMeasure.Should().NotBeNull();
+        result.Value.DestinationUnitOfMeasure.Name.Should().Be(_uoms[0].Name);
+        result.Value.ConversionRatio.Should().Be(command.ConversionRatio);
+
+    }
+
+    [Fact]
+    public async Task Update_With_Duplicate_Source_And_Destination_Is_Not_Possible()
+    {
+        // Arrange        
+        await _fixture.AddAsync(new Data.Entity.UnitConversion() { SourceUnitOfMeasureId = _uoms[1].Id, DestinationUnitOfMeasureId = _uoms[0].Id, ConversionRatio = 1m });
+        var command = new UpdateUnitConversion() { Id = _conversion.Id, SourceUnitOfMeasureId = _uoms[1].Id, DestinationUnitOfMeasureId = _uoms[0].Id, ConversionRatio = 5m };
+
+        // Act
+        var result = await _fixture.SendAsync(command);
+
+        // Assert
+        result.WasFailure.Should().BeTrue();
+        result.StatusCode.Should().Be(System.Net.HttpStatusCode.BadRequest);
+        result.Errors.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task Update_With_Negative_ConversionRatio_Is_Not_Possible()
+    {
+        // Arrange
+        var command = new UpdateUnitConversion() { Id = _conversion.Id, SourceUnitOfMeasureId = _uoms[0].Id, DestinationUnitOfMeasureId = _uoms[1].Id, ConversionRatio = -5m };
+
+        // Act
+        var result = await _fixture.SendAsync(command);
+
+        // Assert
+        result.WasFailure.Should().BeTrue();
+        result.StatusCode.Should().Be(System.Net.HttpStatusCode.BadRequest);
+        result.Errors.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task Update_With_Zero_ConversionRatio_Is_Not_Possible()
+    {
+        // Arrange
+        var command = new UpdateUnitConversion() { Id = _conversion.Id, SourceUnitOfMeasureId = _uoms[0].Id, DestinationUnitOfMeasureId = _uoms[1].Id, ConversionRatio = 0m };
+
+        // Act
+        var result = await _fixture.SendAsync(command);
+
+        // Assert
+        result.WasFailure.Should().BeTrue();
+        result.StatusCode.Should().Be(System.Net.HttpStatusCode.BadRequest);
+        result.Errors.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task Update_With_Invalid_SourceUnitOfMeasureId_Is_Not_Possible()
+    {
+        // Arrange
+        var command = new UpdateUnitConversion() { Id = _conversion.Id, SourceUnitOfMeasureId = 0, DestinationUnitOfMeasureId = _uoms[1].Id, ConversionRatio = 5m };
+
+        // Act
+        var result = await _fixture.SendAsync(command);
+
+        // Assert
+        result.WasFailure.Should().BeTrue();
+        result.StatusCode.Should().Be(System.Net.HttpStatusCode.BadRequest);
+        result.Errors.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task Update_With_Invalid_DestinationUnitOfMeasureId_Is_Not_Possible()
+    {
+        // Arrange
+        var command = new UpdateUnitConversion() { Id = _conversion.Id, SourceUnitOfMeasureId = _uoms[0].Id, DestinationUnitOfMeasureId = 0, ConversionRatio = 5m };
+
+        // Act
+        var result = await _fixture.SendAsync(command);
+
+        // Assert
+        result.WasFailure.Should().BeTrue();
+        result.StatusCode.Should().Be(System.Net.HttpStatusCode.BadRequest);
+        result.Errors.Should().HaveCount(1);
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _fixture.ResetDatabase();
+    }
+}

--- a/PriceTracker.Testing/UnitOfMeasure/Commands/CreateUnitOfMeasureTests.cs
+++ b/PriceTracker.Testing/UnitOfMeasure/Commands/CreateUnitOfMeasureTests.cs
@@ -17,7 +17,7 @@ public class CreateUnitOfMeasureTests : IAsyncLifetime, IClassFixture<BaseTestFi
     public async Task Create_With_Valid_Values_Is_Possible()
     {
         // Arrange        
-        var createCommand = new CreateUnitOfMeasure() { Name = "ounce", Abbreviation = "oz", ConversionToGramsRatio = 28.5m };
+        var createCommand = new CreateUnitOfMeasure() { Name = "ounce", Abbreviation = "oz" };
 
         // Act
         var result = await _scope.SendAsync(createCommand);
@@ -27,15 +27,14 @@ public class CreateUnitOfMeasureTests : IAsyncLifetime, IClassFixture<BaseTestFi
         result.Value.Should().NotBeNull();
         result.Value.Name.Should().Be(createCommand.Name);
         result.Value.Abbreviation.Should().Be(createCommand.Abbreviation);
-        result.Value.ConversionToGramsRatio.Should().Be(createCommand.ConversionToGramsRatio);
     }
 
     [Fact]
     public async Task Create_With_Duplicate_Name_Is_Not_Possible()
     {
         // Arrange 
-        await _scope.AddAsync(new Data.Entity.UnitOfMeasure() { Name = "ounce", Abbreviation = "o", ConversionToGramsRatio = 28.5m });
-        var createCommand = new CreateUnitOfMeasure() { Name = "ounce", Abbreviation = "oz", ConversionToGramsRatio = 28.5m };
+        await _scope.AddAsync(new Data.Entity.UnitOfMeasure() { Name = "ounce", Abbreviation = "o" });
+        var createCommand = new CreateUnitOfMeasure() { Name = "ounce", Abbreviation = "oz" };
 
         // Act
         var result = await _scope.SendAsync(createCommand);
@@ -50,8 +49,8 @@ public class CreateUnitOfMeasureTests : IAsyncLifetime, IClassFixture<BaseTestFi
     public async Task Create_With_Duplicate_Abbreviation_Is_Not_Possible()
     {
         // Arrange
-        await _scope.AddAsync(new Data.Entity.UnitOfMeasure() { Name = "ounces", Abbreviation = "oz", ConversionToGramsRatio = 28.5m });
-        var createCommand = new CreateUnitOfMeasure() { Name = "ounce", Abbreviation = "oz", ConversionToGramsRatio = 28.5m };
+        await _scope.AddAsync(new Data.Entity.UnitOfMeasure() { Name = "ounces", Abbreviation = "oz" });
+        var createCommand = new CreateUnitOfMeasure() { Name = "ounce", Abbreviation = "oz" };
 
         // Act
         var result = await _scope.SendAsync(createCommand);
@@ -66,7 +65,7 @@ public class CreateUnitOfMeasureTests : IAsyncLifetime, IClassFixture<BaseTestFi
     public async Task Create_Without_Name_Is_Not_Possible()
     {
         // Arrange
-        var createCommand = new CreateUnitOfMeasure() { Name = "", Abbreviation = "oz", ConversionToGramsRatio = 28.5m };
+        var createCommand = new CreateUnitOfMeasure() { Name = "", Abbreviation = "oz" };
 
         // Act
         var result = await _scope.SendAsync(createCommand);
@@ -80,35 +79,7 @@ public class CreateUnitOfMeasureTests : IAsyncLifetime, IClassFixture<BaseTestFi
     public async Task Create_Without_Abbreviation_Is_Not_Possible()
     {
         // Arrange
-        var createCommand = new CreateUnitOfMeasure() { Name = "ounce", Abbreviation = "", ConversionToGramsRatio = 28.5m };
-
-        // Act
-        var result = await _scope.SendAsync(createCommand);
-
-        // Assert
-        result.WasSuccess.Should().BeFalse();
-        result.StatusCode.Should().Be(System.Net.HttpStatusCode.BadRequest);
-    }
-
-    [Fact]
-    public async Task Create_With_Negative_Conversion_Ratio_Is_Not_Possible()
-    {
-        // Arrange
-        var createCommand = new CreateUnitOfMeasure() { Name = "ounce", Abbreviation = "", ConversionToGramsRatio = -28.5m };
-
-        // Act
-        var result = await _scope.SendAsync(createCommand);
-
-        // Assert
-        result.WasSuccess.Should().BeFalse();
-        result.StatusCode.Should().Be(System.Net.HttpStatusCode.BadRequest);
-    }
-
-    [Fact]
-    public async Task Create_With_Zero_Conversion_Ratio_Is_Not_Possible()
-    {
-        // Arrange
-        var createCommand = new CreateUnitOfMeasure() { Name = "ounce", Abbreviation = "", ConversionToGramsRatio = 0m };
+        var createCommand = new CreateUnitOfMeasure() { Name = "ounce", Abbreviation = "" };
 
         // Act
         var result = await _scope.SendAsync(createCommand);

--- a/PriceTracker.Testing/UnitOfMeasure/Commands/DeleteUnitOfMeasureTests.cs
+++ b/PriceTracker.Testing/UnitOfMeasure/Commands/DeleteUnitOfMeasureTests.cs
@@ -19,9 +19,9 @@ public class DeleteUnitOfMeasureTests : IAsyncLifetime, IClassFixture<BaseTestFi
         // Seed data
         entities = new List<Data.Entity.UnitOfMeasure>()
         {
-            new Data.Entity.UnitOfMeasure() { Name = "ounces", Abbreviation = "ozs", ConversionToGramsRatio = 1.0m },
-            new Data.Entity.UnitOfMeasure() { Name = "pounds", Abbreviation = "lbs", ConversionToGramsRatio = 1.0m },
-            new Data.Entity.UnitOfMeasure() { Name = "grams", Abbreviation = "gs", ConversionToGramsRatio = 1.0m }
+            new Data.Entity.UnitOfMeasure() { Name = "ounces", Abbreviation = "ozs" },
+            new Data.Entity.UnitOfMeasure() { Name = "pounds", Abbreviation = "lbs" },
+            new Data.Entity.UnitOfMeasure() { Name = "grams", Abbreviation = "gs" }
         };
         await _fixture.AddRangeAsync(entities);
     }

--- a/PriceTracker.Testing/UnitOfMeasure/Commands/UpdateUnitOfMeasureTests.cs
+++ b/PriceTracker.Testing/UnitOfMeasure/Commands/UpdateUnitOfMeasureTests.cs
@@ -19,9 +19,9 @@ public class UpdateUnitOfMeasureTests : IAsyncLifetime, IClassFixture<BaseTestFi
         // Seed data
         entities = new List<Data.Entity.UnitOfMeasure>()
         {
-            new Data.Entity.UnitOfMeasure() { Name = "ounces", Abbreviation = "ozs", ConversionToGramsRatio = 1.0m },
-            new Data.Entity.UnitOfMeasure() { Name = "pounds", Abbreviation = "lbs", ConversionToGramsRatio = 1.0m },
-            new Data.Entity.UnitOfMeasure() { Name = "grams", Abbreviation = "gs", ConversionToGramsRatio = 1.0m }
+            new Data.Entity.UnitOfMeasure() { Name = "ounces", Abbreviation = "ozs" },
+            new Data.Entity.UnitOfMeasure() { Name = "pounds", Abbreviation = "lbs" },
+            new Data.Entity.UnitOfMeasure() { Name = "grams", Abbreviation = "gs" }
         };
         await _fixture.AddRangeAsync(entities);
     }
@@ -30,7 +30,7 @@ public class UpdateUnitOfMeasureTests : IAsyncLifetime, IClassFixture<BaseTestFi
     public async Task Update_With_Valid_Values_Is_Possible()
     {
         // Arrange
-        var command = new UpdateUnitOfMeasure() { Id = entities[0].Id, Name = "ounce", Abbreviation = "oz", ConversionToGramsRatio = 28.5m };
+        var command = new UpdateUnitOfMeasure() { Id = entities[0].Id, Name = "ounce", Abbreviation = "oz" };
 
         // Act
         var result = await _fixture.SendAsync(command);
@@ -40,14 +40,13 @@ public class UpdateUnitOfMeasureTests : IAsyncLifetime, IClassFixture<BaseTestFi
         result.Value.Should().NotBeNull();
         result.Value.Name.Should().Be(command.Name);
         result.Value.Abbreviation.Should().Be(command.Abbreviation);
-        result.Value.ConversionToGramsRatio.Should().Be(command.ConversionToGramsRatio);
     }
 
     [Fact]
     public async Task Update_With_Duplicate_Name_Is_Not_Possible()
     {
         // Arrange
-        var command = new UpdateUnitOfMeasure() { Id = entities[1].Id, Name = "grams", Abbreviation = "g", ConversionToGramsRatio = 1.0m };
+        var command = new UpdateUnitOfMeasure() { Id = entities[1].Id, Name = "grams", Abbreviation = "g" };
 
         // Act
         var result = await _fixture.SendAsync(command);
@@ -61,7 +60,7 @@ public class UpdateUnitOfMeasureTests : IAsyncLifetime, IClassFixture<BaseTestFi
     public async Task Update_With_Duplicate_Abbreviation_Is_Not_Possible()
     {
         // Arrange
-        var command = new UpdateUnitOfMeasure() { Id = entities[1].Id, Name = "gram", Abbreviation = "gs", ConversionToGramsRatio = 1.0m };
+        var command = new UpdateUnitOfMeasure() { Id = entities[1].Id, Name = "gram", Abbreviation = "gs" };
 
         // Act
         var result = await _fixture.SendAsync(command);
@@ -75,7 +74,7 @@ public class UpdateUnitOfMeasureTests : IAsyncLifetime, IClassFixture<BaseTestFi
     public async Task Update_With_Empty_Name_Is_Not_Possible()
     {
         // Arrange
-        var command = new UpdateUnitOfMeasure() { Id = entities[1].Id, Name = "", Abbreviation = "lb", ConversionToGramsRatio = 1.0m };
+        var command = new UpdateUnitOfMeasure() { Id = entities[1].Id, Name = "", Abbreviation = "lb" };
 
         // Act
         var result = await _fixture.SendAsync(command);
@@ -89,35 +88,7 @@ public class UpdateUnitOfMeasureTests : IAsyncLifetime, IClassFixture<BaseTestFi
     public async Task Update_With_Empty_Abbreviation_Is_Not_Possible()
     {
         // Arrange
-        var command = new UpdateUnitOfMeasure() { Id = entities[1].Id, Name = "pound", Abbreviation = "", ConversionToGramsRatio = 1.0m };
-
-        // Act
-        var result = await _fixture.SendAsync(command);
-
-        // Assert
-        result.WasSuccess.Should().BeFalse();
-        result.StatusCode.Should().Be(System.Net.HttpStatusCode.BadRequest);
-    }
-
-    [Fact]
-    public async Task Update_With_Negative_Conversion_Ratio_Is_Not_Possible()
-    {
-        // Arrange
-        var command = new UpdateUnitOfMeasure() { Id = entities[1].Id, Name = "pound", Abbreviation = "lb", ConversionToGramsRatio = -1.0m };
-
-        // Act
-        var result = await _fixture.SendAsync(command);
-
-        // Assert
-        result.WasSuccess.Should().BeFalse();
-        result.StatusCode.Should().Be(System.Net.HttpStatusCode.BadRequest);
-    }
-
-    [Fact]
-    public async Task Update_With_Zero_Conversion_Ratio_Is_Not_Possible()
-    {
-        // Arrange
-        var command = new UpdateUnitOfMeasure() { Id = entities[1].Id, Name = "pound", Abbreviation = "lb", ConversionToGramsRatio = 0.0m };
+        var command = new UpdateUnitOfMeasure() { Id = entities[1].Id, Name = "pound", Abbreviation = "" };
 
         // Act
         var result = await _fixture.SendAsync(command);
@@ -131,7 +102,7 @@ public class UpdateUnitOfMeasureTests : IAsyncLifetime, IClassFixture<BaseTestFi
     public async Task Update_With_Invalid_Id_Is_Not_Possible()
     {
         // Arrange
-        var command = new UpdateUnitOfMeasure() { Id = 0, Name = "pound", Abbreviation = "lb", ConversionToGramsRatio = 1.0m };
+        var command = new UpdateUnitOfMeasure() { Id = 0, Name = "pound", Abbreviation = "lb" };
 
         // Act
         var result = await _fixture.SendAsync(command);


### PR DESCRIPTION
Switches to use a unit conversion table to convert between units of measure instead of the base ConversionToGrams property. This allows for conversions to not have as many decimal rounding discrepancies.